### PR TITLE
Implement proper support for beta releases (#4)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,13 @@
 #!/usr/bin/env node
-require("./lib/main")();
+var argv = require("yargs")
+  .usage("Usage: $0 [options]")
+  .boolean("b")
+  .alias("b", "beta")
+  .describe("b", "Get beta releases")
+  .help("h")
+  .alias("h", "help")
+  .argv;
+
+if (! argv.h) {
+  require("./lib/main")(argv);
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "cheerio": "^0.19.0",
     "superagent": "^1.2.0",
     "superagent-bluebird-promise": "^2.0.2",
-    "tmp": "0.0.26"
+    "tmp": "0.0.26",
+    "yargs": "^4.2.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
Similar to #4 we add a flag to get the latest beta release (as well as comparing version with the current installed beta version). This pr actually uses the public GitHub API instead of parsing the releases page, as we can easier filter the releases based on if it's a pre-release tag.
