### PR TITLE
Properly parses new Atom version string

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6,10 +6,11 @@ import tmp from "tmp";
 
 function getInstalledVersion() {
   try {
-    return child.execSync("atom --version", {
+    const version = child.execSync("atom --version", {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"]
     }).trim();
+    return version.match(/^Atom *: *([0-9.]*)$/m)[1] || version;
   } catch (err) {
     if (err.status === 127) {
       return null;


### PR DESCRIPTION
New versions of Atom return versions of all its components when running `atom --version` and that breaks the version check:

``` bash
$ atom --version
Atom    : 1.10.2
Electron: 0.37.8
Chrome  : 49.0.2623.75
Node    : 5.10.0
```

The change adds a conditional RegExp to properly parse and extract the version from this new response format.

Thanks for this awesome package!!!
